### PR TITLE
Some fixes and enhancements regarding file formats and script parsing

### DIFF
--- a/Axis2/Axis2.cpp
+++ b/Axis2/Axis2.cpp
@@ -165,12 +165,11 @@ BOOL CAxis2App::InitInstance()
 	csProfilePath = GetRegistryString("Default ProfilePath", "");
 	if ( csProfilePath == "" )
 	{
-		CString pathSelected;
-		CFolderDialog dlgfolder(&pathSelected, CMsg("IDS_DEFAULT_PROFILE_FOLDER"));
-		if (dlgfolder.DoModal() == IDOK)
+		TCHAR pathSelected[MAX_PATH];
+		if(GetPathDlg(NULL, pathSelected, CMsg("IDS_DEFAULT_PROFILE_FOLDER")) == TRUE)
 			csProfilePath = pathSelected;
 		else
-			csProfilePath = "C:/Sphere";
+			csProfilePath = "C:\\Sphere";
 		PutRegistryString("Default ProfilePath", csProfilePath);
 		PutRegistryString("Last Profile Loaded", CMsg("IDS_AXIS_PROFILE"));
 	}
@@ -296,7 +295,11 @@ BOOL CAxis2App::InitInstance()
 	{
 		dlg.OnOpenSettingsPage(0);
 		PutRegistryDword("Initallize", 0);
-		PutRegistryString("Default Profile", CMsg("IDS_AXIS_PROFILE"));
+		csProfilePath = GetRegistryString("Default ProfilePath", "");
+		if (csProfilePath == "") 
+		{
+			PutRegistryString("Default Profile", CMsg("IDS_AXIS_PROFILE"));
+		}
 	}
 #endif
 
@@ -917,7 +920,7 @@ void CAxis2App::LoadSounds()
 					{
 						cfSoundmul.Seek(pSound->dwStart,CFile::begin);
 						cfSoundmul.Read( &cName, 32 );
-						cName[32] = 0x00;
+						cName[31] = 0x00;
 						CString csName = cName;
 						csName = csName.SpanExcluding(".");
 						pSound->csName = csName;

--- a/Axis2/Axis2.cpp
+++ b/Axis2/Axis2.cpp
@@ -68,7 +68,7 @@ BOOL CAxis2App::InitInstance()
 	m_pcppAxisLogTab->m_dcCurrentPage = m_pcppAxisLogTab;
 	m_pScripts = new CScriptObjects;
 	m_log.Add(0,CFMsg(CMsg("IDS_START"), Main->GetVersionTitle(), Main->GetBuildTimestamp()));
-	m_csCurentProfile = CMsg("IDS_NONE");
+	m_csCurrentProfile = CMsg("IDS_NONE");
 
 	//*******************************
 	// Load the Default settings
@@ -237,6 +237,7 @@ BOOL CAxis2App::InitInstance()
 	dlg.AddPage(m_pcppReminderTab);
 	dlg.AddPage(m_pcppAxisLogTab);
 
+	m_pAxisMainWnd = &dlg;
 	m_pMainWnd = &dlg;
 
 
@@ -704,8 +705,8 @@ void CAxis2App::UpdateProfileMenu()
 
 	if (pSubMenu)
 	{
-		pSubMenu->ModifyMenu(2,MF_BYPOSITION | MF_STRING,ID_PROFILES_UNLOAD,CFMsg(CMsg("IDS_UNLOAD_PROFILE"),m_csCurentProfile));
-		if (m_csCurentProfile == CMsg("IDS_NONE"))
+		pSubMenu->ModifyMenu(2,MF_BYPOSITION | MF_STRING,ID_PROFILES_UNLOAD,CFMsg(CMsg("IDS_UNLOAD_PROFILE"),m_csCurrentProfile));
+		if (m_csCurrentProfile == CMsg("IDS_NONE"))
 			pSubMenu->EnableMenuItem(2, MF_BYPOSITION | MF_GRAYED);
 		else
 			pSubMenu->EnableMenuItem(2, MF_BYPOSITION | MF_ENABLED);

--- a/Axis2/Axis2.h
+++ b/Axis2/Axis2.h
@@ -89,7 +89,7 @@ public:
 	CString GetBuildTimestamp();
 	CString GetRegistryString(CString csValue, CString csDefault = "", HKEY hMainKey = hRegLocation, CString csSubKey = REGKEY_AXIS);
 	CString m_csPosition;
-	CString m_csCurentProfile;
+	CString m_csCurrentProfile;
 	CString m_csRootDirectory;
 	CAdvStringArray pLng;
 	bool LoadLang();
@@ -157,6 +157,7 @@ public:
 	CAxis2App();
 	virtual ~CAxis2App();
 
+	CAxis2Dlg* m_pAxisMainWnd;
 	CAxisLog m_log;
 
 	CScriptObjects * m_pScripts;

--- a/Axis2/Axis2Dlg.cpp
+++ b/Axis2/Axis2Dlg.cpp
@@ -152,7 +152,7 @@ int CAxis2Dlg::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	m_nid.uCallbackMessage = WM_USER;
 	m_nid.hIcon = m_hIcon;
 	CString csTip;
-	csTip.Format("%s (%s)", Main->GetVersionTitle(), Main->m_csCurentProfile);
+	csTip.Format("%s (%s)", Main->GetVersionTitle(), Main->m_csCurrentProfile);
 	strcpy_s(m_nid.szTip,sizeof(m_nid.szTip), csTip);
 	Shell_NotifyIcon(NIM_ADD, &m_nid);
 	m_bModeless = 1;
@@ -240,11 +240,17 @@ void CAxis2Dlg::UpdateTip()
 	m_nid.uCallbackMessage = WM_USER;
 	m_nid.hIcon = m_hIcon;
 	CString csTip;
-	csTip.Format("%s (%s)", Main->GetVersionTitle(), Main->m_csCurentProfile);
+	csTip.Format("%s (%s)", Main->GetVersionTitle(), Main->m_csCurrentProfile);
 	strcpy_s(m_nid.szTip,sizeof(m_nid.szTip), csTip);
 	Shell_NotifyIcon(NIM_MODIFY, &m_nid);
 }
 
+void CAxis2Dlg::ReloadActiveTabPage()
+{
+	int active = this->GetActiveIndex();
+	this->SetActivePage(-1);
+	this->SetActivePage(active);
+}
 
 //Settings Menu
 
@@ -309,7 +315,7 @@ void CAxis2Dlg::OnUnloadProfile()
 	Main->m_pScripts->UnloadProfile();
 	Main->LoadIni(1);
 	Main->LoadIni(2);
-	Main->m_csCurentProfile = CMsg(IDS_NONE);
+	Main->m_csCurrentProfile = CMsg(IDS_NONE);
 	UpdateTip();
 	AfxBeginThread(LoadProfileThread,(LPVOID)0);
 }
@@ -319,7 +325,7 @@ void CAxis2Dlg::OnLoadDefProfile()
 	Main->m_pScripts->UnloadProfile();
 	Main->LoadIni(1);
 	Main->LoadIni(2);
-	Main->m_csCurentProfile = Main->GetRegistryString("Default Profile");
+	Main->m_csCurrentProfile = Main->GetRegistryString("Default Profile");
 	UpdateTip();
 	AfxBeginThread(LoadProfileThread,(LPVOID)1);
 }
@@ -329,7 +335,7 @@ void CAxis2Dlg::OnLoadLastProfile()
 	Main->m_pScripts->UnloadProfile();
 	Main->LoadIni(1);
 	Main->LoadIni(2);
-	Main->m_csCurentProfile = Main->GetRegistryString("Last Profile Loaded");
+	Main->m_csCurrentProfile = Main->GetRegistryString("Last Profile Loaded");
 	UpdateTip();
 	AfxBeginThread(LoadProfileThread,(LPVOID)0);
 }

--- a/Axis2/Axis2Dlg.h
+++ b/Axis2/Axis2Dlg.h
@@ -62,6 +62,8 @@ public:
 // Implementation
 public:
 	void UpdateTip();
+	void ReloadActiveTabPage();
+
 	NOTIFYICONDATA m_nid;
 	 CAxis2Dlg();
 	HICON m_hIcon;

--- a/Axis2/Common.cpp
+++ b/Axis2/Common.cpp
@@ -481,7 +481,7 @@ int CScriptArray::Find(CString csName)
 	return -1;
 }
 
-int CScriptArray::FindSimilar(CTObject * pScript)
+int CScriptArray::Find(CString csName, BYTE type)
 {
 	if ( this->GetSize() == 0 )
 		return -1;
@@ -494,9 +494,9 @@ int CScriptArray::FindSimilar(CTObject * pScript)
 		iIndex = (iUpper + iLower ) / 2;
 		CSObject * pTest = (CSObject *) this->GetAt(iIndex);
 		CString csExisting = pTest->m_csValue;
-		if ( csExisting.CompareNoCase(pScript->m_csValue) == 0 && pScript->m_bType == pTest->m_bType )
+		if ( csExisting.CompareNoCase(csName) == 0 && pTest->m_bType == type)
 				return (int)iIndex;
-		if ( csExisting.CompareNoCase(pScript->m_csValue) > 0 )
+		if ( csExisting.CompareNoCase(csName) > 0 )
 			iUpper = iIndex - 1;
 		else
 			iLower = iIndex + 1;
@@ -941,7 +941,7 @@ UINT LoadProfileThread(LPVOID pParam)
 		sProfile = Main->GetRegistryString("Default Profile");
 	else
 	{
-		sProfile = Main->m_csCurentProfile;
+		sProfile = Main->m_csCurrentProfile;
 	}
 
 	Main->m_pScripts->LoadProfile(sProfile);

--- a/Axis2/Common.cpp
+++ b/Axis2/Common.cpp
@@ -481,6 +481,29 @@ int CScriptArray::Find(CString csName)
 	return -1;
 }
 
+int CScriptArray::FindSimilar(CTObject * pScript)
+{
+	if ( this->GetSize() == 0 )
+		return -1;
+
+	INT_PTR iLower = 0;
+	INT_PTR iUpper = this->GetUpperBound();
+	INT_PTR iIndex = 0;
+	while ( iLower <= iUpper )
+	{
+		iIndex = (iUpper + iLower ) / 2;
+		CSObject * pTest = (CSObject *) this->GetAt(iIndex);
+		CString csExisting = pTest->m_csValue;
+		if ( csExisting.CompareNoCase(pScript->m_csValue) == 0 && pScript->m_bType == pTest->m_bType )
+				return (int)iIndex;
+		if ( csExisting.CompareNoCase(pScript->m_csValue) > 0 )
+			iUpper = iIndex - 1;
+		else
+			iLower = iIndex + 1;
+	}
+	return -1;
+}
+
 int CScriptArray::Insert(CTObject * pScript)
 {
 	if (( pScript->m_csValue == "" )&&( !pScript->m_bCustom ))

--- a/Axis2/Common.h
+++ b/Axis2/Common.h
@@ -82,6 +82,7 @@ public:
 	~CScriptArray();
 	int Insert(CTObject * pScript);
 	int Find(CString csName);
+	int FindSimilar(CTObject * pScript);
 	CString GetDef(CString csName);
 };
 

--- a/Axis2/Common.h
+++ b/Axis2/Common.h
@@ -82,7 +82,7 @@ public:
 	~CScriptArray();
 	int Insert(CTObject * pScript);
 	int Find(CString csName);
-	int FindSimilar(CTObject * pScript);
+	int Find(CString csName, BYTE type);
 	CString GetDef(CString csName);
 };
 

--- a/Axis2/ItemTab.cpp
+++ b/Axis2/ItemTab.cpp
@@ -1098,7 +1098,7 @@ void CItemTab::OnSaveQuicklist(CString csList)
 		CSObject * pObject = (CSObject *) Main->m_pScripts->m_ItemQuickList.GetAt(iCount);
 		aQuicklist.Add(pObject->m_csValue);
 		CString csProfileKey;
-		csProfileKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurentProfile);
+		csProfileKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurrentProfile);
 		Main->PutRegistryMultiSz(csList, &aQuicklist, hRegLocation, csProfileKey);
 	}
 }

--- a/Axis2/Profile_DLG.cpp
+++ b/Axis2/Profile_DLG.cpp
@@ -668,14 +668,9 @@ void CProfileDLG::OnCancelprofile()
 
 void CProfileDLG::OnDirbrowse() 
 {
-
-	CString pathSelected, m_csBaseDir;
-	CFolderDialog dlg(&pathSelected,"Choose folder");
-	m_ceBaseDir.GetWindowText(m_csBaseDir);
-	dlg.m_ofn.lpstrInitialDir = m_csBaseDir;
-	if (dlg.DoModal() == IDOK)
+	TCHAR pathSelected[MAX_PATH];
+	if (GetPathDlg(this->GetSafeHwnd(), pathSelected, _T("Choose folder")) == TRUE)
 		m_ceBaseDir.SetWindowText(pathSelected);
-	return;	
 }
 
 void CProfileDLG::OnLoadScripts()

--- a/Axis2/Profile_DLG.cpp
+++ b/Axis2/Profile_DLG.cpp
@@ -128,7 +128,7 @@ BOOL CProfileDLG::OnInitDialog()
 	LONG lStatus;
 	int iIndex = 0;
 	CString csCruProf, csDefault;
-	csCruProf.Format("Current Profile : %s",Main->m_csCurentProfile);
+	csCruProf.Format("Current Profile : %s",Main->m_csCurrentProfile);
 	m_ceCurProfile.SetWindowText(csCruProf);
 	csDefault = Main->GetRegistryString("Default Profile", "");
 	m_clbProfiles.AddString("<Axis Profile>");
@@ -682,7 +682,7 @@ void CProfileDLG::OnLoadScripts()
 	m_ceName.GetWindowText(m_csName);
 	csCruProf.Format("Current Profile : %s",m_csName);
 	m_ceCurProfile.SetWindowText(csCruProf);
-	Main->m_csCurentProfile = m_csName;
+	Main->m_csCurrentProfile = m_csName;
 	CAxis2Dlg * hParent = (CAxis2Dlg *)this->GetParent();
 	hParent->UpdateTip();
 	AfxBeginThread(LoadProfileThread,(LPVOID)0);
@@ -852,7 +852,7 @@ void CProfileDLG::OnExport()
 	CString csLine, csFile;
 	CStdioFile pFile;
 
-	CFileDialog dlg(FALSE, "scp", Main->m_csCurentProfile, OFN_HIDEREADONLY, "Script Files (*.scp)|*.scp||" , NULL);
+	CFileDialog dlg(FALSE, "scp", Main->m_csCurrentProfile, OFN_HIDEREADONLY, "Script Files (*.scp)|*.scp||" , NULL);
 	if ( dlg.DoModal() == IDOK )
 	{
 		csFile = dlg.GetFileName();

--- a/Axis2/ScriptObjects.cpp
+++ b/Axis2/ScriptObjects.cpp
@@ -319,10 +319,11 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 
 								csLine = pItem->ReadBlock(*pFile);
 
-								int iOld = m_aItems.Find(pItem->m_csValue);
+								int iOld = m_aItems.FindSimilar(pItem); // Similar lookup respects type. This is required since items and multis share thier id range.
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_ITEM"), pItem->m_csID, pItem->m_csDisplay));
 									m_aItems.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -340,10 +341,11 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 
 								csLine = pItem->ReadBlock(*pFile);
 
-								int iOld = m_aItems.Find(pItem->m_csValue);
+								int iOld = m_aItems.FindSimilar(pItem); // Similar lookup respects type. This is required since items and multis share thier id range.
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_MULTI"), pItem->m_csID, pItem->m_csDisplay));
 									m_aItems.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -365,6 +367,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_TEMPLATE"), pTempl->m_csID, pTempl->m_csDisplay));
 									m_aItems.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -386,6 +389,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aNPCs.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_CHAR"), pNPC->m_csID, pNPC->m_csDisplay));
 									m_aNPCs.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -407,6 +411,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aNPCs.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_SPAWN"), pSpawn->m_csID, pSpawn->m_csDisplay));
 									m_aNPCs.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -430,6 +435,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aAreas.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_LOCATION"), pArea->m_csID, pArea->m_csValue));
 									m_aAreas.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -595,6 +601,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aSpellList.GetAt(iOld);
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_SPELL"), pSpell->m_csID, pSpell->m_csDisplay));
 									m_aSpellList.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -716,7 +723,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 												CStdioFile * pLoadFile = new CStdioFile;
 												if ( !pLoadFile->Open(csLoadFile, CFile::modeRead | CFile::shareDenyNone) )
 												{
-													Main->m_log.Add(1,"ERROR: Unable to open file %s", csLoadFile);
+													Main->m_log.Add(1, CFMsg(CMsg("IDS_WARNING_NOOPEN"), csLoadFile));
 													continue;
 												}
 												LoadFile(pLoadFile);
@@ -734,7 +741,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 							}
 							break;
 						default:
-							Main->m_log.Add(1,"Unknown section %s in file %s", csLine, csFile);
+							Main->m_log.Add(1, CFMsg(CMsg("IDS_WARNING_UNKNOWN_SECTION"), csLine, csFile));
 							bStatus = pFile->ReadString(csLine);
 							break;
 						}

--- a/Axis2/ScriptObjects.cpp
+++ b/Axis2/ScriptObjects.cpp
@@ -318,16 +318,22 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								pItem->m_csFilename = csFile;	
 
 								csLine = pItem->ReadBlock(*pFile);
-
-								int iOld = m_aItems.FindSimilar(pItem); // Similar lookup respects type. This is required since items and multis share thier id range.
-								if ( iOld != -1 )
+								if (pItem->m_csCategory.Find('$') == 0) // Hidden definition
 								{
-									CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_ITEM"), pItem->m_csID, pItem->m_csDisplay));
-									m_aItems.RemoveAt(iOld);
-									delete pOld;
+									delete pItem;
 								}
-								m_aItems.Insert(pItem);
+								else
+								{
+									int iOld = m_aItems.Find(pItem->m_csValue, pItem->m_bType); // Similar lookup respects type. This is required since items and multis share thier id range.
+									if ( iOld != -1 )
+									{
+										CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
+										Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_ITEM"), pItem->m_csID, pItem->m_csDisplay));
+										m_aItems.RemoveAt(iOld);
+										delete pOld;
+									}
+									m_aItems.Insert(pItem);
+								}
 							}
 							break;
 						case RES_MULTIDEF:
@@ -340,16 +346,22 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								pItem->m_csFilename = csFile;	
 
 								csLine = pItem->ReadBlock(*pFile);
-
-								int iOld = m_aItems.FindSimilar(pItem); // Similar lookup respects type. This is required since items and multis share thier id range.
-								if ( iOld != -1 )
+								if(pItem->m_csCategory.Find('$') == 0) // Hidden definition
 								{
-									CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_MULTI"), pItem->m_csID, pItem->m_csDisplay));
-									m_aItems.RemoveAt(iOld);
-									delete pOld;
+									delete pItem;
 								}
-								m_aItems.Insert(pItem);
+								else 
+								{
+									int iOld = m_aItems.Find(pItem->m_csValue, pItem->m_bType); // Similar lookup respects type. This is required since items and multis share thier id range.
+									if (iOld != -1)
+									{
+										CSObject * pOld = (CSObject *)m_aItems.GetAt(iOld);
+										Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_MULTI"), pItem->m_csID, pItem->m_csDisplay));
+										m_aItems.RemoveAt(iOld);
+										delete pOld;
+									}
+									m_aItems.Insert(pItem);
+								}
 							}
 							break;
 						case RES_TEMPLATE:
@@ -362,16 +374,22 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								pTempl->m_csFilename = csFile;	
 
 								csLine = pTempl->ReadBlock(*pFile);
-
-								int iOld = m_aItems.Find(pTempl->m_csValue);
-								if ( iOld != -1 )
+								if (pTempl->m_csCategory.Find('$') == 0) // Hidden definition
 								{
-									CSObject * pOld = (CSObject *) m_aItems.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_TEMPLATE"), pTempl->m_csID, pTempl->m_csDisplay));
-									m_aItems.RemoveAt(iOld);
-									delete pOld;
+									delete pTempl;
 								}
-								m_aItems.Insert(pTempl);
+								else
+								{
+									int iOld = m_aItems.Find(pTempl->m_csValue);
+									if (iOld != -1)
+									{
+										CSObject * pOld = (CSObject *)m_aItems.GetAt(iOld);
+										Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_TEMPLATE"), pTempl->m_csID, pTempl->m_csDisplay));
+										m_aItems.RemoveAt(iOld);
+										delete pOld;
+									}
+									m_aItems.Insert(pTempl);
+								}
 							}
 							break;
 						case RES_CHARDEF:
@@ -384,16 +402,22 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								pNPC->m_csFilename = csFile;
 
 								csLine = pNPC->ReadBlock(*pFile);
-
-								int iOld = m_aNPCs.Find(pNPC->m_csValue);
-								if ( iOld != -1 )
+								if (pNPC->m_csCategory.Find('$') == 0) // Hidden definition
 								{
-									CSObject * pOld = (CSObject *) m_aNPCs.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_CHAR"), pNPC->m_csID, pNPC->m_csDisplay));
-									m_aNPCs.RemoveAt(iOld);
-									delete pOld;
+									delete pNPC;
 								}
-								m_aNPCs.Insert(pNPC);
+								else
+								{
+									int iOld = m_aNPCs.Find(pNPC->m_csValue);
+									if (iOld != -1)
+									{
+										CSObject * pOld = (CSObject *)m_aNPCs.GetAt(iOld);
+										Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_CHAR"), pNPC->m_csID, pNPC->m_csDisplay));
+										m_aNPCs.RemoveAt(iOld);
+										delete pOld;
+									}
+									m_aNPCs.Insert(pNPC);
+								}
 							}
 							break;
 						case RES_SPAWN:
@@ -406,16 +430,22 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								pSpawn->m_csFilename = csFile;
 
 								csLine = pSpawn->ReadBlock(*pFile);
-
-								int iOld = m_aNPCs.Find(pSpawn->m_csValue);
-								if ( iOld != -1 )
+								if (pSpawn->m_csCategory.Find('$') == 0) // Hidden definition
 								{
-									CSObject * pOld = (CSObject *) m_aNPCs.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_SPAWN"), pSpawn->m_csID, pSpawn->m_csDisplay));
-									m_aNPCs.RemoveAt(iOld);
-									delete pOld;
+									delete pSpawn;
 								}
-								m_aNPCs.Insert(pSpawn);
+								else
+								{
+									int iOld = m_aNPCs.Find(pSpawn->m_csValue);
+									if (iOld != -1)
+									{
+										CSObject * pOld = (CSObject *)m_aNPCs.GetAt(iOld);
+										Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_SPAWN"), pSpawn->m_csID, pSpawn->m_csDisplay));
+										m_aNPCs.RemoveAt(iOld);
+										delete pOld;
+									}
+									m_aNPCs.Insert(pSpawn);
+								}
 							}
 							break;
 						case RES_AREA:
@@ -430,16 +460,22 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								pArea->m_csFilename = csFile;
 
 								csLine = pArea->ReadBlock(*pFile);
-
-								int iOld = m_aAreas.Find(pArea->m_csValue);
-								if ( iOld != -1 )
+								if (pArea->m_csCategory.Find('$') == 0) // Hidden definition
 								{
-									CSObject * pOld = (CSObject *) m_aAreas.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_LOCATION"), pArea->m_csID, pArea->m_csValue));
-									m_aAreas.RemoveAt(iOld);
-									delete pOld;
+									delete pArea;
 								}
-								m_aAreas.Insert(pArea);
+								else
+								{
+									int iOld = m_aAreas.Find(pArea->m_csValue);
+									if (iOld != -1)
+									{
+										CSObject * pOld = (CSObject *)m_aAreas.GetAt(iOld);
+										Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_LOCATION"), pArea->m_csID, pArea->m_csValue));
+										m_aAreas.RemoveAt(iOld);
+										delete pOld;
+									}
+									m_aAreas.Insert(pArea);
+								}
 							}
 							break;
 						case RES_DEFNAME:
@@ -601,7 +637,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 								if ( iOld != -1 )
 								{
 									CSObject * pOld = (CSObject *) m_aSpellList.GetAt(iOld);
-									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_SPELL"), pSpell->m_csID, pSpell->m_csDisplay));
+									Main->m_log.Add(1, CFMsg(CMsg("IDS_ID_DUPLICATE_SPELL"), pSpell->m_csID, pSpell->m_csValue));
 									m_aSpellList.RemoveAt(iOld);
 									delete pOld;
 								}
@@ -776,7 +812,7 @@ bool CScriptObjects::LoadFile(CStdioFile * pFile, bool bResource, bool bProgress
 void CScriptObjects::LoadQuicklist(CString csList, CScriptArray * pObjList, CScriptArray * pDestList)
 {
 	CString csKey;
-	csKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurentProfile);
+	csKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurrentProfile);
 	CStringArray csaList;
 	Main->GetRegistryMultiSz(csList, &csaList, hRegLocation, csKey);
 
@@ -811,7 +847,7 @@ void CScriptObjects::LoadQuicklist(CString csList, CScriptArray * pObjList, CScr
 
 void CScriptObjects::LoadProfile(CString csProfile)
 {
-		Main->m_csCurentProfile = csProfile;
+		Main->m_csCurrentProfile = csProfile;
 
 		//No Profile
 		if (csProfile == "<None>")
@@ -833,6 +869,7 @@ void CScriptObjects::LoadProfile(CString csProfile)
 			LoadQuicklist("Spawns", &m_aNPCs, &m_SpawnQuickList);
 			LoadQuicklist("Area", &m_aAreas, &m_AreaQuickList);
 			DestroyProgressDialog();
+			Main->m_pAxisMainWnd->ReloadActiveTabPage();
 			return;
 		}
 
@@ -871,6 +908,7 @@ void CScriptObjects::LoadProfile(CString csProfile)
 			LoadQuicklist("Spawns", &m_aNPCs, &m_SpawnQuickList);
 			LoadQuicklist("Area", &m_aAreas, &m_AreaQuickList);
 			DestroyProgressDialog();
+			Main->m_pAxisMainWnd->ReloadActiveTabPage();
 			return;
 		}
 
@@ -1103,6 +1141,7 @@ void CScriptObjects::LoadProfile(CString csProfile)
 			LoadQuicklist("Spawns", &m_aNPCs, &m_SpawnQuickList);
 			LoadQuicklist("Area", &m_aAreas, &m_AreaQuickList);
 			DestroyProgressDialog();
+			Main->m_pAxisMainWnd->ReloadActiveTabPage();
 		}
 }
 
@@ -1199,6 +1238,7 @@ void CScriptObjects::UnloadProfile()
 {
 	delete Main->m_pScripts;
 	Main->m_pScripts = new CScriptObjects;
+	Main->m_pAxisMainWnd->ReloadActiveTabPage();
 }
 
 void CScriptObjects::Unload(CScriptArray * pObjList)
@@ -1281,9 +1321,9 @@ void CScriptObjects::CategorizeObjects(CScriptArray * pObjList, CPtrList * pCatL
 		{
 			if ( pItem->m_csDupeItem != "" )
 			{
-				int iIndex = pObjList->Find(pItem->m_csDupeItem);
+				int iIndex = pObjList->Find(pItem->m_csDupeItem, TYPE_ITEM); // only match dupes for !items!
 				if ( iIndex == -1 )
-					iIndex = pObjList->Find(pObjList->GetDef(pItem->m_csDupeItem));
+					iIndex = pObjList->Find(pObjList->GetDef(pItem->m_csDupeItem), TYPE_ITEM); // only match dupes for !items!
 				if ( iIndex != -1 )
 				{
 					CSObject * pDupe = (CSObject *) pObjList->GetAt(iIndex);

--- a/Axis2/SpawnTab.cpp
+++ b/Axis2/SpawnTab.cpp
@@ -904,7 +904,7 @@ void CSpawnTab::OnSaveQuicklist(CString csList)
 		CSObject * pObject = (CSObject *) Main->m_pScripts->m_SpawnQuickList.GetAt(iCount);
 		aQuicklist.Add(pObject->m_csValue);
 		CString csProfileKey;
-		csProfileKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurentProfile);
+		csProfileKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurrentProfile);
 		Main->PutRegistryMultiSz(csList, &aQuicklist, hRegLocation, csProfileKey);
 	}
 }

--- a/Axis2/TravelTab.cpp
+++ b/Axis2/TravelTab.cpp
@@ -1657,7 +1657,7 @@ void CTravelTab::OnSaveQuicklist(CString csList)
 		CSObject * pObject = (CSObject *) Main->m_pScripts->m_AreaQuickList.GetAt(iCount);
 		aQuicklist.Add(pObject->m_csValue);
 		CString csProfileKey;
-		csProfileKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurentProfile);
+		csProfileKey.Format("%s\\%s\\Quicklist",REGKEY_PROFILE, Main->m_csCurrentProfile);
 		Main->PutRegistryMultiSz(csList, &aQuicklist, hRegLocation, csProfileKey);
 	}
 }

--- a/Axis2/UOart.h
+++ b/Axis2/UOart.h
@@ -73,11 +73,14 @@ public:
 class CMultiRec
 {
 public:
+	CMultiRec() : hue(0) { }
+
 	WORD wIndex;
 	short x;
 	short y;
 	short z;
 	DWORD dwFlags;
+	DWORD hue;
 };
 
 class ArtAddress
@@ -90,11 +93,72 @@ public:
 	DWORD dwCompressedSize;
 };
 
+#pragma pack(1)
+struct OldLandTileData
+{
+	DWORD flags;
+	WORD texID;
+	char name[20];
+};
+#pragma pack(pop) 
+
+#pragma pack(1)
+struct NewLandTileData
+{
+	DWORD flags;
+	DWORD unk1;
+	WORD texID;
+	char name[20];
+};
+#pragma pack(pop) 
+
+#pragma pack(1)
+struct OldItemTileData
+{
+	DWORD Flags;
+	char Weight;
+	char Quality;
+	WORD Unknown;
+	char Unknown1;
+	char Quantity;
+	WORD AnimID;
+	char Unknown2;
+	char Hue;
+	WORD Unknown3;
+	char Height;
+	char Name[20];
+};
+#pragma pack(pop) 
+
+#pragma pack(1)
+struct NewItemTileData
+{
+	DWORD Flags;
+	DWORD Unknown;
+	char Weight;
+	char Quality;
+	WORD Unknown1;
+	char Unknown2;
+	char Quantity;
+	WORD AnimID;
+	char Unknown3;
+	char Hue;
+	WORD Unknown4;
+	char Height;
+	char Name[20];
+};
+#pragma pack(pop) 
+
+
 /////////////////////////////////////////////////////////////////////////////
 // CUOArt class
 
 class CUOArt : public CWnd
 {
+	OldLandTileData* GetOldLandTileData(int id);
+	NewLandTileData* GetNewLandTileData(int id);
+	OldItemTileData* GetOldItemTile(int id);
+	NewItemTileData* GetNewItemTile(int id);
 // Constructor
 public:
 	CUOArt();
@@ -110,10 +174,11 @@ protected:
 	DWORD BlendColors(WORD wBaseColor, WORD wAppliedColor, bool bBlendMode);
 	DWORD ScaleColor(WORD wColor);
 
-	BYTE m_tiledata [0x191800];
+	BYTE m_TileData[0x30A800];
 	WORD m_wArtWidth[0x10000];
 	WORD m_wArtHeight[0x10000];
 	bool m_bArtDataLoaded;
+	bool m_bIsUOAHS;
 	void LoadArtData();
 	void LoadTiledata();
 

--- a/Axis2/stdafx.cpp
+++ b/Axis2/stdafx.cpp
@@ -57,7 +57,7 @@ BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam)
 	pWnd->GetWindowText(csTitle);
 	if ( lParam )
 	{
-		if ((csTitle.Find("Ultima Online") != -1) || (csTitle.Find("UOSA") != -1) || (csTitle.Find(Main->m_csUOTitle) != -1))
+		if ((csTitle.Find("Ultima Online") != -1) || (csTitle.Find("UOSA") != -1) || (Main->m_csUOTitle.GetLength() > 0 && (csTitle.Find(Main->m_csUOTitle) != -1)))
 		{
 			hwndUOClient = hWnd;
 			return FALSE;

--- a/Axis2/stdafx.cpp
+++ b/Axis2/stdafx.cpp
@@ -176,6 +176,8 @@ CFolderDialog::CFolderDialog(CString* pPath, CString csTitle) : CFileDialog(TRUE
 {
 	m_pPath = pPath;
 	m_Title = csTitle;
+
+	this->m_ofn.lpstrTitle = m_Title;
 }
 
 
@@ -231,6 +233,35 @@ void CFolderDialog::OnInitDone()
 	pFD->ScreenToClient(rectList2);
 	pFD->GetDlgItem(lst1)->SetWindowPos(0,0,0,rectList2.Width(), abs(rectList2.top - (rectCancel.top - 4)), SWP_NOMOVE | SWP_NOZORDER);
 	SetControlText(IDOK, _T("Select"));
-	pFD->SetWindowText(m_Title);
+	pFD->SetWindowText(m_Title);	
+	
 	m_wndProc = (WNDPROC)SetWindowLongPtr(pFD->m_hWnd, GWL_WNDPROC, (__int3264)(LONG_PTR)WindowProcNew);
+}
+
+BOOL GetPathDlg(HWND owner, TCHAR *dest, CString csTitle)
+{
+	TCHAR selectedPath[MAX_PATH];
+	BOOL ret = FALSE;
+	BROWSEINFO bi;
+	LPITEMIDLIST il;
+
+	CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+	memset(&bi, 0, sizeof(BROWSEINFO));
+	bi.hwndOwner = owner;
+	bi.lpszTitle = csTitle;
+	bi.ulFlags = BIF_USENEWUI;
+	il = SHBrowseForFolder(&bi);
+	if (il != NULL)
+	{
+		if (SHGetPathFromIDList(il, selectedPath))
+		{
+			_tcsncpy(dest, selectedPath, MAX_PATH);
+			ret = TRUE;
+		}
+		CoTaskMemFree(il);
+	}
+
+	CoUninitialize();
+
+	return ret;
 }

--- a/Axis2/stdafx.h
+++ b/Axis2/stdafx.h
@@ -525,3 +525,5 @@ protected:
 
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
+
+BOOL GetPathDlg(HWND owner, TCHAR *dest, CString csTitle);

--- a/release/Language/eng.lng
+++ b/release/Language/eng.lng
@@ -6,7 +6,7 @@ IDS_ADDDESTINATION=Custom Destination Editor
 IDS_ADMIN=Admin
 IDS_ALLMOVE=Allmove
 IDS_AXIS_PROFILE=<Axis Profile>
-IDS_AXIS_VERSION=Axis2 v%1 (Alathair Mod)
+IDS_AXIS_VERSION=Axis2 version %1
 IDS_AXISTITLE=%1 - Press F1 for Help
 
 IDS_BAN=Ban

--- a/release/Language/eng.lng
+++ b/release/Language/eng.lng
@@ -6,7 +6,7 @@ IDS_ADDDESTINATION=Custom Destination Editor
 IDS_ADMIN=Admin
 IDS_ALLMOVE=Allmove
 IDS_AXIS_PROFILE=<Axis Profile>
-IDS_AXIS_VERSION=Axis2 version %1
+IDS_AXIS_VERSION=Axis2 v%1 (Alathair Mod)
 IDS_AXISTITLE=%1 - Press F1 for Help
 
 IDS_BAN=Ban
@@ -122,6 +122,13 @@ IDS_INVIS=Invisible
 IDS_INVUL=Invul
 IDS_ITEMS=Items
 IDS_ITEM_TWEAK=Item Tweak
+IDS_ID_DUPLICATE_ITEM=ERROR: Duplicate item id/defname %1 (%2)
+IDS_ID_DUPLICATE_CHAR=ERROR: Duplicate character id/defname %1 (%2)
+IDS_ID_DUPLICATE_MULTI=ERROR: Duplicate multi id/defname %1 (%2)
+IDS_ID_DUPLICATE_TEMPLATE=ERROR: Duplicate template id/defname %1 (%2)
+IDS_ID_DUPLICATE_SPAWN=ERROR: Duplicate spawn id/defname %1 (%2)
+IDS_ID_DUPLICATE_LOCATION=ERROR: Duplicate area id/defname %1 (%2)
+IDS_ID_DUPLICATE_SPELL=ERROR: Duplicate spell id/defname %1 (%2)
 
 IDS_JAIL=Jail
 

--- a/release/changelog.txt
+++ b/release/changelog.txt
@@ -369,3 +369,16 @@
  -Removed: Incomplete language selection option from the settings
  -Added: Disable toolbar mode option on the general settings tab to disable the toolbar mode when minimized.
  -Added: Custom Client Title option in general settings to allow for custom client titles to be recognised by Axis.
+ 
+ 
+ 
+ ***Version 2.0.?*** (ares@alathair.de)
+ 
+ +September 08, 2018+
+ -Fixed: sound.mul crash bug
+ -Fixed: missing multis in item tab
+ -Fixed/Replaced: Nonworking folder pickers.
+ -Added: AOS Multi Support
+ -Added: Error logging for faulty scripts
+ -Added: AOS Art&Tiledata Support
+ -Added: Partial Hue Item Preview

--- a/release/changelog.txt
+++ b/release/changelog.txt
@@ -382,3 +382,4 @@
  -Added: Error logging for faulty scripts
  -Added: AOS Art&Tiledata Support
  -Added: Partial Hue Item Preview
+ -Fixed: Client window lookup with empty custom client title should work now and will not find an empty title system window.

--- a/release/changelog.txt
+++ b/release/changelog.txt
@@ -374,7 +374,7 @@
  
  ***Version 2.0.?*** (ares@alathair.de)
  
- +September 08, 2018+
+ +September 16, 2018+
  -Fixed: sound.mul crash bug
  -Fixed: missing multis in item tab
  -Fixed/Replaced: Nonworking folder pickers.
@@ -383,3 +383,7 @@
  -Added: AOS Art&Tiledata Support
  -Added: Partial Hue Item Preview
  -Fixed: Client window lookup with empty custom client title should work now and will not find an empty title system window.
+ -Fixed: Dupeitems should not appear anymore for corresponding multi ids.
+ -Added: Categories starting with '$' will be ignored and not be shown in any list.
+ -Fixed: More usefull debug hint for duplicate spells.
+ -Fixed: Active tab will be refreshed after loading/unloading a profile. So interacting with it will not cause crashes anymore.


### PR DESCRIPTION
-Fixed: sound.mul crash bug
-Fixed: missing multis in item tab (these were caused by overlaps with item ids. This should be gone right now.)
-Fixed/Replaced: Nonworking folder pickers. (somehow the picker dialog was simply useless.)
-Added: AOS Multi Support (An entry here has 16 bytes not 12)
-Added: Error logging for faulty scripts (to identify issues why something is not shown correctly.)
-Added: AOS Art&Tiledata Support (arts ands tiledata should be read to the end.)
-Added: Partial Hue Item Preview (Just nice to have)